### PR TITLE
Install and run current version of htaccess tool in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,8 @@ jobs:
     steps:
       - name: Clear composer cache
         run: composer clear-cache
-      - name: Extract branch name
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
       - name: Require this branch
-        run: composer require madewithlove/htaccess:dev-${{ steps.extract_branch.outputs.branch }}
+        run: composer require madewithlove/htaccess:dev-${GITHUB_REF##*/}#$GITHUB_SHA
       - name: Add a very basic htaccess file
         run: echo "RewriteRule .* /foo" >> .htaccess
       - name: Run the htaccess tester

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
         args: analyse
 
   install-and-test:
-    name: Check that this is installable through composer
+    name: Check that this is installable and usable
     runs-on: ubuntu-latest
     steps:
       - name: Clear composer cache
         run: composer clear-cache
-      - name: Require this branch
+      - name: Require this version
         run: composer require madewithlove/htaccess:dev-${GITHUB_REF##*/}#$GITHUB_SHA
       - name: Add a very basic htaccess file
         run: echo "RewriteRule .* /foo" >> .htaccess

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,19 @@ jobs:
       uses: docker://oskarstark/phpstan-ga
       with:
         args: analyse
+
+  install-and-test:
+    name: Check that this is installable through composer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear composer cache
+        run: composer clear-cache
+      - name: Extract branch name
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Require this branch
+        run: composer require madewithlove/htaccess:dev-${{ steps.extract_branch.outputs.branch }}
+      - name: Add a very basic htaccess file
+        run: echo "RewriteRule .* /foo" >> .htaccess
+      - name: Run the htaccess tester
+        run: vendor/bin/htaccess http://localhost

--- a/bin/htaccess
+++ b/bin/htaccess
@@ -1,7 +1,19 @@
 #!/usr/bin/env php
 <?php declare(strict_types=1);
 
-require __DIR__.'/../vendor/autoload.php';
+$potentialAutoloadLocations = [
+    __DIR__ . '/vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../vendor/autoload.php',
+    __DIR__ . '/../../../vendor/autoload.php',
+];
+
+foreach ($potentialAutoloadLocations as $file) {
+    if (file_exists($file)) {
+        require_once $file;
+        break;
+    }
+}
 
 use Http\Adapter\Guzzle6\Client;
 use Http\Factory\Guzzle\ServerRequestFactory;

--- a/bin/htaccess
+++ b/bin/htaccess
@@ -2,10 +2,8 @@
 <?php declare(strict_types=1);
 
 $potentialAutoloadLocations = [
-    __DIR__ . '/vendor/autoload.php',
     __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/../../vendor/autoload.php',
-    __DIR__ . '/../../../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
 ];
 
 foreach ($potentialAutoloadLocations as $file) {


### PR DESCRIPTION
We want to do this because we want to be sure that our tool is installable and runnable at every point.

This PR also fixes that you can actually run the tool when installing it through composer.