### PR TITLE
Add referrer and server name options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Where the url is the request url you want to test your .htaccess file with.
 
 ![Screenshot 2019-11-21 at 12 28 53](https://user-images.githubusercontent.com/1398405/69334214-8cf9ea00-0c5a-11ea-8ee8-06f397719289.png)
 
+### CLI Options
+
+The following options are available:
+
+```
+-r, --referrer[=REFERRER]        The referrer header, used as HTTP_REFERER in apache
+-s, --server-name[=SERVER-NAME]  The configured server name, used as SERVER_NAME in apache
+```
+
 ### Note
 
 The tool simulates only one pass through the server, while Apache will do multiple if you get back

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following options are available:
 ```
 -r, --referrer[=REFERRER]        The referrer header, used as HTTP_REFERER in apache
 -s, --server-name[=SERVER-NAME]  The configured server name, used as SERVER_NAME in apache
+-h, --help                       Display a help message
 ```
 
 ### Note

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "symfony/console": "^3.0 || ^4.0",
         "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",
-        "madewithlove/htaccess-api-client": "^1.0"
+        "madewithlove/htaccess-api-client": "^1.1"
     },
     "bin": [
         "bin/htaccess"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c067da1007cf19d28298407c30b1c18",
+    "content-hash": "96e78d0f9e352004da5f70ea4497f7bd",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -246,19 +246,20 @@
         },
         {
             "name": "madewithlove/htaccess-api-client",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/madewithlove/htaccess-api-client.git",
-                "reference": "79c8faf5fb409af7947995aaa25c5db6c3eacd77"
+                "reference": "ade035facfa01e295913921e33dce864c68d9fb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/madewithlove/htaccess-api-client/zipball/79c8faf5fb409af7947995aaa25c5db6c3eacd77",
-                "reference": "79c8faf5fb409af7947995aaa25c5db6c3eacd77",
+                "url": "https://api.github.com/repos/madewithlove/htaccess-api-client/zipball/ade035facfa01e295913921e33dce864c68d9fb8",
+                "reference": "ade035facfa01e295913921e33dce864c68d9fb8",
                 "shasum": ""
             },
             "require": {
+                "php": "^7.2",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0"
             },
@@ -278,7 +279,7 @@
                 "GPL-3.0-or-later"
             ],
             "description": "API client for the best htaccess tester in the world.",
-            "time": "2019-11-20T15:18:08+00:00"
+            "time": "2019-11-21T11:31:12+00:00"
         },
         {
             "name": "php-http/guzzle6-adapter",

--- a/src/HtaccessCommand.php
+++ b/src/HtaccessCommand.php
@@ -6,6 +6,7 @@ use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -28,6 +29,7 @@ final class HtaccessCommand extends Command
     protected function configure()
     {
         $this->addArgument('url', InputArgument::REQUIRED, 'The request url to test your .htaccess file with');
+        $this->addOption('referrer', 'r', InputOption::VALUE_OPTIONAL, 'The referrer header, used as HTTP_REFERER in apache');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -45,7 +47,8 @@ final class HtaccessCommand extends Command
 
         $result = $this->htaccessClient->test(
             $url,
-            $htaccess
+            $htaccess,
+            $input->getOption('referrer')
         );
 
         $io->table(

--- a/src/HtaccessCommand.php
+++ b/src/HtaccessCommand.php
@@ -30,6 +30,7 @@ final class HtaccessCommand extends Command
     {
         $this->addArgument('url', InputArgument::REQUIRED, 'The request url to test your .htaccess file with');
         $this->addOption('referrer', 'r', InputOption::VALUE_OPTIONAL, 'The referrer header, used as HTTP_REFERER in apache');
+        $this->addOption('server-name', 's', InputOption::VALUE_OPTIONAL, 'The configured server name, used as SERVER_NAME in apache');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -48,7 +49,8 @@ final class HtaccessCommand extends Command
         $result = $this->htaccessClient->test(
             $url,
             $htaccess,
-            $input->getOption('referrer')
+            $input->getOption('referrer'),
+            $input->getOption('server-name')
         );
 
         $io->table(


### PR DESCRIPTION
This PR adds the following CLI options:

```
-r, --referrer[=REFERRER]        The referrer header, used as HTTP_REFERER in apache
-s, --server-name[=SERVER-NAME]  The configured server name, used as SERVER_NAME in apache
```

These can be used to pass a referer or a server name to the htaccess tester API.

Fixes #4 