### PR TITLE
Publish docker containers when new tags come available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Clear composer cache
         run: composer clear-cache
       - name: Require this version
-        run: composer require madewithlove/htaccess:dev-${GITHUB_REF##*/}#$GITHUB_SHA --prefer-source
+        run: composer require madewithlove/htaccess-cli:dev-${GITHUB_REF##*/}#$GITHUB_SHA --prefer-source
       - name: Add a very basic htaccess file
         run: echo "RewriteRule .* /foo" >> .htaccess
       - name: Run the htaccess tester

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -16,3 +16,5 @@ jobs:
           DOCKER_HUB_LOGIN: ${{ secrets.DOCKER_HUB_LOGIN }}
           DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
         run: docker login -u ${DOCKER_HUB_LOGIN} -p ${DOCKER_HUB_PASS}
+      - name: Get tag name
+        run: echo ${GITHUB_REF##*/}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -1,4 +1,4 @@
-name: Continious Integration
+name: Publish new tags to Docker Hub
 
 on:
   push:

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -15,4 +15,4 @@ jobs:
         env:
           DOCKER_HUB_LOGIN: ${{ secrets.DOCKER_HUB_LOGIN }}
           DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
-        run: docker login -u ${DOCKER_HUB_LOGIN} --password-stdin ${DOCKER_HUB_PASS}
+        run: docker login -u ${DOCKER_HUB_LOGIN} -p ${DOCKER_HUB_PASS}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -1,10 +1,9 @@
 name: Continious Integration
 
 on:
-  push
-#  push:
-#    tags:
-#      - 'v*'
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   docker-publish:
@@ -24,3 +23,5 @@ jobs:
         run: sleep 60
       - name: Build docker container
         run: docker build --build-arg VERSION=${{ steps.get_version.outputs.version }} -f Dockerfile --tag madewithlove/htaccess-cli:${{ steps.get_version.outputs.version }} .
+      - name: Publish docker container to Docker Hub
+        run: docker push madewithlove/htaccess-cli:${{ steps.get_version.outputs.version }}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -19,5 +19,7 @@ jobs:
       - name: Get version name
         id: get_version
         run: echo ::set-output name=version::$(echo ${GITHUB_REF##*/} | cut -c2-)
-      - name: output version name
-        run: echo ${{ steps.get_version.outputs.version }}
+      - name: Wait for package to become available on packagist
+        run: sleep 60
+      - name: Build docker container
+        run: docker build --build-arg VERSION=${{ steps.get_version.outputs.version }} -f Dockerfile --tag madewithlove/htaccess-cli:${{ steps.get_version.outputs.version }} .

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -18,6 +18,6 @@ jobs:
         run: docker login -u ${DOCKER_HUB_LOGIN} -p ${DOCKER_HUB_PASS}
       - name: Get version name
         id: get_version
-        run: echo ::set-output name=version::$(echo ${GITHUB_REF##*/:1} | cut -c2-)
+        run: echo ::set-output name=version::$(echo ${GITHUB_REF##*/} | cut -c2-)
       - name: output version name
         run: echo ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -16,5 +16,8 @@ jobs:
           DOCKER_HUB_LOGIN: ${{ secrets.DOCKER_HUB_LOGIN }}
           DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
         run: docker login -u ${DOCKER_HUB_LOGIN} -p ${DOCKER_HUB_PASS}
-      - name: Get tag name
-        run: echo ${GITHUB_REF##*/:1}
+      - name: Get version name
+        id: get_version
+        run: echo ::set-output name=version::$(echo ${GITHUB_REF##*/:1} | cut -c2-)
+      - name: output version name
+        run: echo ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -1,0 +1,18 @@
+name: Continious Integration
+
+on:
+  push
+#  push:
+#    tags:
+#      - 'v*'
+
+jobs:
+  docker-publish:
+    name: Publish new tag to Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do a docker login
+        env:
+          DOCKER_HUB_LOGIN: ${{ secrets.DOCKER_HUB_LOGIN }}
+          DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
+        run: docker login -u ${DOCKER_HUB_LOGIN} --password-stdin ${DOCKER_HUB_PASS}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -17,4 +17,4 @@ jobs:
           DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
         run: docker login -u ${DOCKER_HUB_LOGIN} -p ${DOCKER_HUB_PASS}
       - name: Get tag name
-        run: echo ${GITHUB_REF##*/}
+        run: echo ${GITHUB_REF##*/:1}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -11,6 +11,7 @@ jobs:
     name: Publish new tag to Docker
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@master
       - name: Do a docker login
         env:
           DOCKER_HUB_LOGIN: ${{ secrets.DOCKER_HUB_LOGIN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:cli-alpine
+
+ENV COMPOSER_HOME /composer
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV PATH /composer/vendor/bin:$PATH
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+ARG VERSION
+
+RUN composer global require madewithlove/htaccess:"$VERSION"
+
+VOLUME ["/app"]
+WORKDIR /app
+
+ENTRYPOINT ["htaccess"]


### PR DESCRIPTION
This PR makes sure that docker containers are automatically pushed to docker hub when a new version is tagged.

Yet to be confirmed that it works when adding the next tag. I'll only document the docker version once this is confirmed to work when adding new tags.