### PR TITLE
Document usage through docker

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -25,3 +25,7 @@ jobs:
         run: docker build --build-arg VERSION=${{ steps.get_version.outputs.version }} -f Dockerfile --tag madewithlove/htaccess-cli:${{ steps.get_version.outputs.version }} .
       - name: Publish docker container to Docker Hub
         run: docker push madewithlove/htaccess-cli:${{ steps.get_version.outputs.version }}
+      - name: Build docker container as latest
+        run: docker build --build-arg VERSION=${{ steps.get_version.outputs.version }} -f Dockerfile --tag madewithlove/htaccess-cli:latest .
+      - name: Publish docker container to Docker Hub
+        run: docker push madewithlove/htaccess-cli:latest

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Where the url is the request url you want to test your .htaccess file with.
 
 ![Screenshot 2019-11-21 at 12 28 53](https://user-images.githubusercontent.com/1398405/69334214-8cf9ea00-0c5a-11ea-8ee8-06f397719289.png)
 
+### Usage through Docker
+
+```bash
+# install the container
+docker pull madewithlove/htaccess-cli:latest
+
+# run the htaccess tester in the current folder
+docker run --rm -v $PWD:/app madewithlove/htaccess-cli [url] <options>
+```
+
 ### CLI Options
 
 The following options are available:


### PR DESCRIPTION
Note that I needed to add a "latest" tag to be able to just use `docker pull madewithlove/htaccess-cli` without a specified version.