### PR TITLE
Add global installation as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ This allows you to use the tool as `htaccess` from every location in your system
 If your .htaccess file lives in your root directory, you can run the cli tool using
 
 ```bash
+# using global installation
 htaccess http://localhost/foo
+
+# using project-specific installation
+vendor/bin/htaccess http://localhost/foo
 ```
 
 Where the url is the request url you want to test your .htaccess file with.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Where the url is the request url you want to test your .htaccess file with.
 
 ```bash
 # install the container
-docker pull madewithlove/htaccess-cli:latest
+docker pull madewithlove/htaccess-cli
 
 # run the htaccess tester in the current folder
 docker run --rm -v $PWD:/app madewithlove/htaccess-cli [url] <options>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A CLI tool to test how .htaccess files behave
 
-### Installation
+## Installation
 
 To start performing analysis on your code, require htaccess CLI in Composer:
 
@@ -12,8 +12,16 @@ composer require --dev madewithlove/htaccess-cli
 
 Composer will install htaccess-cli's executable in its bin-dir which defaults to vendor/bin.
 
+### Global installation
 
-### Usage
+```bash
+composer global require madewithlove/htaccess-cli
+```
+
+Then make sure you have the global Composer binaries directory in your ``PATH``. This directory is platform-dependent, see `Composer documentation <https://getcomposer.org/doc/03-cli.md#composer-home>`_ for details.
+This allows you to use the tool as `htaccess` from every location in your system.
+
+## Usage
 
 If your .htaccess file lives in your root directory, you can run the cli tool using
 
@@ -35,7 +43,7 @@ docker pull madewithlove/htaccess-cli:latest
 docker run --rm -v $PWD:/app madewithlove/htaccess-cli [url] <options>
 ```
 
-### CLI Options
+## CLI Options
 
 The following options are available:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ vendor/bin/htaccess http://localhost/foo
 
 Where the url is the request url you want to test your .htaccess file with.
 
-![Screenshot 2019-11-21 at 12 28 53](https://user-images.githubusercontent.com/1398405/69334214-8cf9ea00-0c5a-11ea-8ee8-06f397719289.png)
+![Screenshot 2019-11-21 at 16 34 40](https://user-images.githubusercontent.com/1398405/69352228-d65b3100-0c7c-11ea-8bed-ae938cec538c.png)
 
 ### Usage through Docker
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This allows you to use the tool as `htaccess` from every location in your system
 
 ## Usage
 
-If your .htaccess file lives in your root directory, you can run the cli tool using
+Run the .htaccess CLI tester from a directory containing a .htaccess file.
 
 ```bash
 # using global installation


### PR DESCRIPTION
Note that I changed some headers to have some more structure.

I also updated some more documentation to make it more clear

This is how it looks like after global install:

![Screenshot 2019-11-21 at 16 34 40](https://user-images.githubusercontent.com/1398405/69352228-d65b3100-0c7c-11ea-8bed-ae938cec538c.png)
