### PR TITLE
Initialize Guzzle client with a custom User-Agent header

### DIFF
--- a/bin/htaccess
+++ b/bin/htaccess
@@ -22,7 +22,11 @@ use Symfony\Component\Console\Application;
 $application = new Application();
 
 $htaccessClient = new HtaccessClient(
-    new Client(),
+    Client::createWithConfig([
+        'headers' => [
+            'User-Agent' => 'HtaccessCli',
+        ],
+    ]),
     new ServerRequestFactory()
 );
 


### PR DESCRIPTION
This will make sure that all htaccess-cli requests (at least from future
versions) will happen using a custom header and that we can thus keep
track of the usage of the tool.