### PR TITLE
Add support for PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0']
     steps:
     - uses: actions/checkout@master
     - uses: shivammathur/setup-php@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     steps:
     - uses: actions/checkout@master
     - uses: shivammathur/setup-php@v1
@@ -25,6 +25,10 @@ jobs:
         coverage: pcov
     - name: Install dependencies
       run: composer install -n --prefer-dist
+      if: matrix.php-versions != '8.0'
+    - name: Install dependencies
+      run: composer self-update --snapshot && composer install -n --prefer-dist --ignore-platform-req=php
+      if: matrix.php-versions == '8.0'
     - name: Run PHPUnit unit tests
       run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
     - uses: codecov/codecov-action@v1

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "CLI interface for the best htaccess tester in the world.",
     "type": "package",
     "require": {
+        "php": "^7.2|^8.0",
         "symfony/console": "^3.0 || ^4.0 || ^5.0",
         "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "CLI interface for the best htaccess tester in the world.",
     "type": "package",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "symfony/console": "^3.0 || ^4.0 || ^5.0",
         "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",


### PR DESCRIPTION
### Added
* tests are now run against PHP 8
* the supported PHP versions are added to the composer.json file

### Removed
* support for PHP7.2 (which wasn't officially given but was implied by the tests)