### PR TITLE
Make "unsupported" more clear in the CLI output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/console": "^3.0 || ^4.0 || ^5.0",
         "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",
-        "madewithlove/htaccess-api-client": "^1.3",
+        "madewithlove/htaccess-api-client": "^1.5",
         "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
     },
     "bin": [

--- a/src/Htaccess/TableRenderer.php
+++ b/src/Htaccess/TableRenderer.php
@@ -21,7 +21,9 @@ final class TableRenderer
             array_map(
                 function (ResultLine $resultLine): array {
                     return [
-                        $this->prettifyBoolean($resultLine->isValid()),
+                        $resultLine->isSupported()
+                            ? $this->prettifyBoolean($resultLine->isValid())
+                            : '<comment>?</comment>',
                         $this->prettifyBoolean($resultLine->wasReached()),
                         $this->prettifyBoolean($resultLine->isMet()),
                         $resultLine->getLine(),

--- a/tests/HtaccessCommandTest.php
+++ b/tests/HtaccessCommandTest.php
@@ -164,4 +164,24 @@ final class HtaccessCommandTest extends TestCase
             $commandTester->getDisplay()
         );
     }
+
+    /** @test */
+    public function it does mark an unsupported line as potentially invalid(): void
+    {
+        file_put_contents(
+            getcwd() . '/tests/.htaccess',
+            "<IfModule mod_rewrite.c>"
+        );
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([
+            'url' => 'http://localhost',
+            '--path' => getcwd() . '/tests',
+        ]);
+
+        $this->assertStringContainsString(
+            '?',
+            $commandTester->getDisplay()
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/madewithlove/htaccess-cli/issues/49

![Screen Shot 2020-11-27 at 15 58 58](https://user-images.githubusercontent.com/1398405/100461898-b2b99a80-30c9-11eb-9128-3d2dcdee3a38.png)
