### PR TITLE
Upgrade to htaccess-api-client v3 and modernise tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: '8.4'
         tools: composer
     - name: Install dependencies
       run: composer update -n --prefer-dist
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.4', '8.5']
         prefer-lowest: ['', '--prefer-lowest']
     steps:
     - uses: actions/checkout@master
@@ -30,23 +30,23 @@ jobs:
         coverage: pcov
         tools: composer
     - name: Install dependencies
-      if: matrix.php-versions != '8.1'
       run: composer update -n --prefer-dist ${{ matrix.prefer-lowest }}
-    - name: Install dependencies
-      if: matrix.php-versions == '8.1'
-      run: composer install -n --prefer-dist --ignore-platform-req=php
     - name: Run PHPUnit unit tests
       run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-      if: matrix.php-versions == '8.0'
+      if: matrix.php-versions == '8.4'
 
   run:
     name: Run current version
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        tools: composer
     - name: Install dependencies
       run: composer install -n --prefer-dist
     - name: Add a very basic htaccess file

--- a/bin/htaccess
+++ b/bin/htaccess
@@ -16,7 +16,7 @@ foreach ($potentialAutoloadLocations as $file) {
 use Http\Adapter\Guzzle7\Client;
 use Http\Factory\Guzzle\ServerRequestFactory;
 use Madewithlove\Htaccess\TableRenderer;
-use Madewithlove\HtaccessClient;
+use Madewithlove\HtaccessApiClient\HtaccessClient;
 use Madewithlove\HtaccessCommand;
 use Symfony\Component\Console\Application;
 

--- a/bin/htaccess
+++ b/bin/htaccess
@@ -32,7 +32,7 @@ $htaccessClient = new HtaccessClient(
 );
 
 $htaccessCommand = new HtaccessCommand($htaccessClient, new TableRenderer());
-$application->add($htaccessCommand);
+$application->addCommand($htaccessCommand);
 $application->setDefaultCommand($htaccessCommand->getName(), true);
 
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "CLI interface for the best htaccess tester in the world.",
     "type": "package",
     "require": {
-        "php": "^8.0",
-        "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "php": "^8.4",
+        "symfony/console": "^7.0 || ^8.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "php-http/guzzle7-adapter": "^1.0",
-        "madewithlove/htaccess-api-client": "^2.3",
-        "symfony/yaml": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+        "madewithlove/htaccess-api-client": "^3.0",
+        "symfony/yaml": "^7.0 || ^8.0"
     },
     "bin": [
         "bin/htaccess"
@@ -21,8 +21,8 @@
     },
     "license": "GPL-3.0-or-later",
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.0.0"
+        "phpunit/phpunit": "^13.0",
+        "phpstan/phpstan": "^2.0"
     },
     "config": {
         "allow-plugins": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,9 +4,9 @@
     <testsuite name="Tests">
         <directory>tests</directory>
     </testsuite>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/Htaccess/TableRenderer.php
+++ b/src/Htaccess/TableRenderer.php
@@ -2,8 +2,8 @@
 
 namespace Madewithlove\Htaccess;
 
-use Madewithlove\HtaccessResult;
-use Madewithlove\ResultLine;
+use Madewithlove\HtaccessApiClient\HtaccessResult;
+use Madewithlove\HtaccessApiClient\ResultLine;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class TableRenderer

--- a/src/HtaccessCommand.php
+++ b/src/HtaccessCommand.php
@@ -4,6 +4,10 @@ namespace Madewithlove;
 
 use InvalidArgumentException;
 use Madewithlove\Htaccess\TableRenderer;
+use Madewithlove\HtaccessApiClient\HtaccessClient;
+use Madewithlove\HtaccessApiClient\HtaccessException;
+use Madewithlove\HtaccessApiClient\HtaccessResult;
+use Madewithlove\HtaccessApiClient\ServerVariables;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;

--- a/src/HtaccessCommand.php
+++ b/src/HtaccessCommand.php
@@ -9,6 +9,7 @@ use Madewithlove\HtaccessApiClient\HtaccessException;
 use Madewithlove\HtaccessApiClient\HtaccessResult;
 use Madewithlove\HtaccessApiClient\ServerVariables;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,15 +19,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Yaml;
 
+#[AsCommand(name: 'htaccess')]
 final class HtaccessCommand extends Command
 {
-    protected static $defaultName = 'htaccess';
-
     public function __construct(
         private HtaccessClient $htaccessClient,
         private TableRenderer $tableRenderer
     ) {
-        parent::__construct(self::$defaultName);
+        parent::__construct();
     }
 
     protected function configure(): void

--- a/tests/HtaccessCommandTest.php
+++ b/tests/HtaccessCommandTest.php
@@ -5,6 +5,8 @@ namespace Madewithlove;
 use Http\Adapter\Guzzle7\Client;
 use Http\Factory\Guzzle\ServerRequestFactory;
 use Madewithlove\Htaccess\TableRenderer;
+use Madewithlove\HtaccessApiClient\HtaccessClient;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -35,7 +37,7 @@ final class HtaccessCommandTest extends TestCase
         @unlink(getcwd() . '/tests/.htaccess');
     }
 
-    /** @test */
+    #[Test]
     public function it does not run without url argument(): void
     {
         $commandTester = new CommandTester($this->command);
@@ -45,7 +47,7 @@ final class HtaccessCommandTest extends TestCase
         $commandTester->execute([]);
     }
 
-    /** @test */
+    #[Test]
     public function it does not run without htaccess file available(): void
     {
         $commandTester = new CommandTester($this->command);
@@ -57,7 +59,7 @@ final class HtaccessCommandTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it does run(): void
     {
         file_put_contents(
@@ -87,7 +89,7 @@ final class HtaccessCommandTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it has exit status zero when expected url is correct(): void
     {
         file_put_contents(
@@ -104,7 +106,7 @@ final class HtaccessCommandTest extends TestCase
         $this->assertEquals(0, $commandTester->getStatusCode());
     }
 
-    /** @test */
+    #[Test]
     public function it has exit status one when expected url is incorrect(): void
     {
         file_put_contents(
@@ -121,7 +123,7 @@ final class HtaccessCommandTest extends TestCase
         $this->assertEquals(1, $commandTester->getStatusCode());
     }
 
-    /** @test */
+    #[Test]
     public function it is possible to share a test run(): void
     {
         file_put_contents(
@@ -141,7 +143,7 @@ final class HtaccessCommandTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it can specify a custom path to the htaccess file(): void
     {
         file_put_contents(
@@ -161,7 +163,7 @@ final class HtaccessCommandTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it does mark an unsupported line as potentially invalid(): void
     {
         file_put_contents(
@@ -181,7 +183,7 @@ final class HtaccessCommandTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it supports http referrer(): void
     {
         file_put_contents(
@@ -201,7 +203,7 @@ final class HtaccessCommandTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it supports server name(): void
     {
         file_put_contents(
@@ -221,7 +223,7 @@ final class HtaccessCommandTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it supports http user agent(): void
     {
         file_put_contents(

--- a/tests/MultipleUrlsTest.php
+++ b/tests/MultipleUrlsTest.php
@@ -5,6 +5,8 @@ namespace Madewithlove;
 use Http\Adapter\Guzzle7\Client;
 use Http\Factory\Guzzle\ServerRequestFactory;
 use Madewithlove\Htaccess\TableRenderer;
+use Madewithlove\HtaccessApiClient\HtaccessClient;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -43,7 +45,7 @@ final class MultipleUrlsTest extends TestCase
         @unlink(getcwd() . '/test-urls.yaml');
     }
 
-    /** @test */
+    #[Test]
     public function it does work if the passed url list is not available(): void
     {
         $commandTester = new CommandTester($this->command);
@@ -55,7 +57,7 @@ final class MultipleUrlsTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it throws when passing both a url and a url list(): void
     {
         $commandTester = new CommandTester($this->command);
@@ -68,7 +70,7 @@ final class MultipleUrlsTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it does run with multiple urls(): void
     {
         file_put_contents(
@@ -99,7 +101,7 @@ final class MultipleUrlsTest extends TestCase
         $this->assertEquals(0, $commandTester->getStatusCode());
     }
 
-    /** @test */
+    #[Test]
     public function it renders status code with multiple urls(): void
     {
         file_put_contents(
@@ -126,7 +128,7 @@ final class MultipleUrlsTest extends TestCase
         $this->assertEquals(0, $commandTester->getStatusCode());
     }
 
-    /** @test */
+    #[Test]
     public function it has exit status one when at least one expected url is incorrect(): void
     {
         file_put_contents(


### PR DESCRIPTION
## Summary

- Integrates **htaccess-api-client v3**, which moves all classes to the `Madewithlove\HtaccessApiClient` namespace and requires PHP 8.4
- Bumps **PHPUnit** to v13 and **PHPStan** to v2
- Narrows **symfony/console** and **symfony/yaml** to `^7.0 || ^8.0`

## Commits

Structured for commit-by-commit review:

1. **composer.json** — version constraint bumps
2. **Namespace migration** — update `use` imports in `HtaccessCommand` and `TableRenderer` to `Madewithlove\HtaccessApiClient\*`
3. **PHPUnit 13** — replace `@test` annotations with `#[Test]` attributes; update `phpunit.xml.dist` coverage config

## Test plan

- [x] `./vendor/bin/phpunit` passes (16 tests, 26 assertions)