### PR TITLE
Align automerge workflow with invox style

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,14 +1,17 @@
 name: Enable automerge on dependabot PRs
 
 on:
+  # See note below about using pull_request_target
   pull_request_target:
 
 jobs:
   automerge:
-    name: Enable automerge on dependabot PRs
+    name: 🚀  Enable automerge on dependabot PRs
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - name: Enable automerge on dependabot PRs
-        run: gh pr merge --merge --auto "1"
+      - name: 🚀  Enable automerge on dependabot PRs
+        run: gh pr merge --merge --auto "$PR_URL"
         env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.DEPENDABOT_AUTO_MERGE_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Use the PR html_url to select the PR (encodes repo + number in one value) and add a job-level guard so the workflow only runs for dependabot-authored PRs, avoiding noisy no-op runs on other PRs.